### PR TITLE
feat: make browser compatible

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,6 @@
+(function () {
+'use strict';
+  
 const utf8Encoder = new TextEncoder()
 const ARRAY16 = new Array(16)
 
@@ -305,4 +308,10 @@ function fn5 (a, b, c, d, e, m, k, s) {
   return (rotl((a + (b ^ (c | (~d))) + m + k) | 0, s) + e) | 0
 }
 
-module.exports = RIPEMD160
+exports.RIPEMD160 = RIPEMD160;
+  
+if ("undefined" !== typeof module) {
+  module.exports = RIPEMD160
+)
+
+}(("undefined" !== typeof module && module.exports) || window);


### PR DESCRIPTION
currently this doesn't work in a browser because browsers don't have `module.export`.

I think this is the simplest way to add browser support without breaking bundlers or node.

I realize it's not formatted properly, just wanted to get a temperature check if you're open to the use case.